### PR TITLE
Add recipes & loot tables; update metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,5 @@ jobs:
           files: "Grid.zip"
           loaders: "datapack"
           game-versions: |-
-            26.1
-            26.1.1
-            26.1.2
+            26.2
           channel: "release"

--- a/data/grid/recipe/blasting/copper_block_from_raw_copper_block.json
+++ b/data/grid/recipe/blasting/copper_block_from_raw_copper_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:blasting",
   "ingredient": "minecraft:raw_copper_block",
-  "result": {
-    "id": "minecraft:copper_block",
     "experience": 1.015,
-    "cookingtime": 450
+    "cookingtime": 450,
+  "result": {
+    "id": "minecraft:copper_block"
   }
 }

--- a/data/grid/recipe/blasting/gold_block_from_raw_gold_block.json
+++ b/data/grid/recipe/blasting/gold_block_from_raw_gold_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:blasting",
   "ingredient": "minecraft:raw_gold_block",
-  "result": {
-    "id": "minecraft:gold_block",
     "experience": 1.015,
-    "cookingtime": 450
+    "cookingtime": 450,
+  "result": {
+    "id": "minecraft:gold_block"
   }
 }

--- a/data/grid/recipe/blasting/iron_block_from_raw_iron_block.json
+++ b/data/grid/recipe/blasting/iron_block_from_raw_iron_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:blasting",
   "ingredient": "minecraft:raw_iron_block",
-  "result": {
-    "id": "minecraft:iron_block",
     "experience": 1.015,
-    "cookingtime": 450
+    "cookingtime": 450,
+  "result": {
+    "id": "minecraft:iron_block"
   }
 }

--- a/data/grid/recipe/crafting/campfire.json
+++ b/data/grid/recipe/crafting/campfire.json
@@ -16,7 +16,14 @@
     "components": {
       "minecraft:block_state": {
         "lit": "false"
-      }
+      },
+      "lore": [
+        {
+            "translate": "subtitles.block.fire.extinguish",
+            "color": "dark_gray",
+            "italic": false
+        }
+      ]
     }
   }
 }

--- a/data/grid/recipe/crafting/clay_ball.json
+++ b/data/grid/recipe/crafting/clay_ball.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:clay"
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:clay_ball"
+  }
+}

--- a/data/grid/recipe/crafting/cobweb.json
+++ b/data/grid/recipe/crafting/cobweb.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "#": "minecraft:string"
+  },
+  "pattern": [
+    "# #",
+    " # ",
+    "# #"
+  ],
+  "result": {
+    "count": 5,
+    "id": "minecraft:cobweb"
+  }
+}

--- a/data/grid/recipe/crafting/copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/copper_golem_spawn_egg.json
@@ -1,0 +1,27 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "L",
+        "C"
+    ],
+    "key": {
+        "L": "minecraft:lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "unaffected"
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/exposed_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/exposed_copper_golem_spawn_egg.json
@@ -1,0 +1,27 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "E",
+        "C"
+    ],
+    "key": {
+        "E": "minecraft:exposed_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:exposed_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "exposed"
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/gravel.json
+++ b/data/grid/recipe/crafting/gravel.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "building",
+  "key": {
+    "#": "minecraft:flint"
+  },
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "result": "minecraft:gravel"
+}

--- a/data/grid/recipe/crafting/invisible_item_frame.json
+++ b/data/grid/recipe/crafting/invisible_item_frame.json
@@ -1,0 +1,29 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "pattern": [
+        "###",
+        "# #",
+        "###"
+    ],
+    "key": {
+        "#": "minecraft:stick"
+    },
+    "result": {
+    "id": "minecraft:item_frame",
+    "components": {
+      "entity_data": {
+        "id": "minecraft:item_frame",
+        "Invisible": true
+      },
+      "lore": [
+        {
+            "translate": "effect.minecraft.invisibility",
+            "color": "dark_gray",
+            "italic": false
+        }
+      ],
+      "enchantment_glint_override": true
+    }
+  }
+}

--- a/data/grid/recipe/crafting/oxidized_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/oxidized_copper_golem_spawn_egg.json
@@ -1,0 +1,27 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "O",
+        "C"
+    ],
+    "key": {
+        "O": "minecraft:oxidized_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:oxidized_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "oxidized"
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/snowball.json
+++ b/data/grid/recipe/crafting/snowball.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:snow"
+  ],
+  "result": "minecraft:snowball"
+}

--- a/data/grid/recipe/crafting/snowball_from_snow_block.json
+++ b/data/grid/recipe/crafting/snowball_from_snow_block.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:snow_block"
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:snowball"
+  }
+}

--- a/data/grid/recipe/crafting/soul_campfire_from_campfire.json
+++ b/data/grid/recipe/crafting/soul_campfire_from_campfire.json
@@ -1,18 +1,16 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "category": "misc",
-  "group": "soul_campfire",
-  "key": {
-    "S": "#minecraft:flammable_ingredients",
-    "F": "#minecraft:soul_fire_base_blocks",
-    "W": "#minecraft:logs"
-  },
-  "pattern": [
-    " S ",
-    "SFS",
-    "WWW"
-  ],
-  "result": {
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "soul_campfire",
+    "pattern": [
+        "C",
+        "S"
+    ],
+    "key": {
+        "C": "minecraft:campfire",
+        "S": "minecraft:soul_soil"
+    },
+    "result": {
     "id": "minecraft:soul_campfire",
     "components": {
       "minecraft:block_state": {

--- a/data/grid/recipe/crafting/sponge.json
+++ b/data/grid/recipe/crafting/sponge.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "#": "minecraft:string",
+    "P": "minecraft:potent_sulfur"
+  },
+  "pattern": [
+    "###",
+    "#P#",
+    "###"
+  ],
+  "result": "minecraft:sponge"
+}

--- a/data/grid/recipe/crafting/string.json
+++ b/data/grid/recipe/crafting/string.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:white_wool"
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:string"
+  }
+}

--- a/data/grid/recipe/crafting/string_from_cobweb.json
+++ b/data/grid/recipe/crafting/string_from_cobweb.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:cobweb"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:string"
+  }
+}

--- a/data/grid/recipe/crafting/unstable_tnt.json
+++ b/data/grid/recipe/crafting/unstable_tnt.json
@@ -18,7 +18,12 @@
         "unstable": "true"
       },
       "minecraft:lore": [
-        "{'translate':'block_states.minecraft.tnt.unstable','fallback':'Unstable','color':'dark_gray','italic':false}"
+        {
+          "translate": "block_states.minecraft.tnt.unstable",
+          "fallback": "Unstable",
+          "color": "dark_gray",
+          "italic": false
+        }
       ],
       "minecraft:enchantment_glint_override": true
     }

--- a/data/grid/recipe/crafting/waxed_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/waxed_copper_golem_spawn_egg.json
@@ -1,0 +1,28 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "W",
+        "C"
+    ],
+    "key": {
+        "W": "minecraft:waxed_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:waxed_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "unaffected",
+        "next_weather_age": -2
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/waxed_exposed_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/waxed_exposed_copper_golem_spawn_egg.json
@@ -1,0 +1,28 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "W",
+        "C"
+    ],
+    "key": {
+        "W": "minecraft:waxed_exposed_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:waxed_exposed_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "exposed",
+        "next_weather_age": -2
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/waxed_oxidized_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/waxed_oxidized_copper_golem_spawn_egg.json
@@ -1,0 +1,28 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "W",
+        "C"
+    ],
+    "key": {
+        "W": "minecraft:waxed_oxidized_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:waxed_oxidized_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "oxidized",
+        "next_weather_age": -2
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/waxed_weathered_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/waxed_weathered_copper_golem_spawn_egg.json
@@ -1,0 +1,28 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "W",
+        "C"
+    ],
+    "key": {
+        "W": "minecraft:waxed_weathered_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:waxed_weathered_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "weathered",
+        "next_weather_age": -2
+      }
+    }
+  }
+}

--- a/data/grid/recipe/crafting/weathered_copper_golem_spawn_egg.json
+++ b/data/grid/recipe/crafting/weathered_copper_golem_spawn_egg.json
@@ -1,0 +1,27 @@
+{
+    "type": "crafting_shaped",
+    "category": "misc",
+    "group": "copper_golem_spawn_egg",
+    "pattern": [
+        "W",
+        "C"
+    ],
+    "key": {
+        "W": "minecraft:weathered_lightning_rod",
+        "C": "minecraft:carved_pumpkin"
+    },
+    "result": {
+    "id": "minecraft:copper_golem_spawn_egg",
+    "components": {
+      "item_model": "minecraft:weathered_copper_golem_statue",
+      "item_name": {
+        "translate": "entity.minecraft.copper_golem"
+      },
+      "enchantment_glint_override": true,
+      "entity_data": {
+        "id": "minecraft:copper_golem",
+        "weather_state": "weathered"
+      }
+    }
+  }
+}

--- a/data/grid/recipe/smelting/copper_block_from_raw_copper_block.json
+++ b/data/grid/recipe/smelting/copper_block_from_raw_copper_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:smelting",
   "ingredient": "minecraft:raw_copper_block",
-  "result": {
-    "id": "minecraft:copper_block",
     "experience": 1.015,
-    "cookingtime": 900
+    "cookingtime": 900,
+  "result": {
+    "id": "minecraft:copper_block"
   }
 }

--- a/data/grid/recipe/smelting/gold_block_from_raw_gold_block.json
+++ b/data/grid/recipe/smelting/gold_block_from_raw_gold_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:smelting",
   "ingredient": "minecraft:raw_gold_block",
-  "result": {
-    "id": "minecraft:gold_block",
     "experience": 1.015,
-    "cookingtime": 900
+    "cookingtime": 900,
+  "result": {
+    "id": "minecraft:gold_block"
   }
 }

--- a/data/grid/recipe/smelting/honey_block.json
+++ b/data/grid/recipe/smelting/honey_block.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smelting",
+  "category": "misc",
+  "cookingtime": 200,
+  "experience": 1,
+  "ingredient": "minecraft:honeycomb_block",
+  "result": {
+    "id": "minecraft:honey_block"
+  }
+}

--- a/data/grid/recipe/smelting/iron_block_from_raw_iron_block.json
+++ b/data/grid/recipe/smelting/iron_block_from_raw_iron_block.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:smelting",
   "ingredient": "minecraft:raw_iron_block",
-  "result": {
-    "id": "minecraft:iron_block",
     "experience": 1.015,
-    "cookingtime": 900
+    "cookingtime": 900,
+  "result": {
+    "id": "minecraft:iron_block"
   }
 }

--- a/data/grid/recipe/smelting/leather_from_rotten_flesh_item.json
+++ b/data/grid/recipe/smelting/leather_from_rotten_flesh_item.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:smelting",
   "ingredient": "minecraft:rotten_flesh",
+    "experience": 1,
+    "cookingtime": 200,
   "result": {
-    "id": "minecraft:leather",
-    "experience": 0.7,
-    "cookingtime": 200
+    "id": "minecraft:leather"
   }
 }

--- a/data/grid/recipe/smithing/anvil.json
+++ b/data/grid/recipe/smithing/anvil.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:smithing_transform",
+    "base": [
+        "minecraft:chipped_anvil",
+        "minecraft:damaged_anvil"
+    ],
+    "addition": "minecraft:iron_block",
+    "result": "minecraft:anvil"
+}

--- a/data/grid/recipe/smoking/honey_block.json
+++ b/data/grid/recipe/smoking/honey_block.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:smoking",
+  "category": "misc",
+  "cookingtime": 100,
+  "experience": 1,
+  "ingredient": "minecraft:honeycomb_block",
+  "result": {
+    "id": "minecraft:honey_block"
+  }
+}

--- a/data/grid/recipe/smoking/leather_from_smoking_rotten_flesh_item.json
+++ b/data/grid/recipe/smoking/leather_from_smoking_rotten_flesh_item.json
@@ -1,9 +1,9 @@
 {
   "type": "minecraft:smoking",
   "ingredient": "minecraft:rotten_flesh",
+    "experience": 1,
+    "cookingtime": 100,
   "result": {
-    "id": "minecraft:leather",
-    "experience": 0.7,
-    "cookingtime": 100
+    "id": "minecraft:leather"
   }
 }

--- a/data/grid/recipe/stonecutting/mangrove_roots.json
+++ b/data/grid/recipe/stonecutting/mangrove_roots.json
@@ -1,0 +1,11 @@
+{
+    "type": "minecraft:stonecutting",
+    "ingredient": [
+        "minecraft:mangrove_log",
+        "minecraft:mangrove_wood"
+    ],
+    "result": {
+        "count": 4,
+        "id": "minecraft:mangrove_roots"
+    }
+}

--- a/data/minecraft/loot_table/blocks/big_dripleaf.json
+++ b/data/minecraft/loot_table/blocks/big_dripleaf.json
@@ -1,0 +1,85 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:big_dripleaf",
+					"conditions": [
+						{
+							"condition": "minecraft:any_of",
+							"terms": [
+								{
+									"condition": "minecraft:match_tool",
+									"predicate": {
+										"items": "minecraft:shears"
+									}
+								},
+								{
+									"condition": "minecraft:match_tool",
+									"predicate": {
+										"predicates": {
+											"minecraft:enchantments": [
+												{
+													"enchantments": "minecraft:silk_touch",
+													"levels": {
+														"min": 1
+													}
+												}
+											]
+										}
+									}
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:small_dripleaf",
+					"conditions": [
+						{
+							"condition": "minecraft:all_of",
+							"terms": [
+								{
+									"condition": "minecraft:inverted",
+									"term": {
+										"condition": "minecraft:match_tool",
+										"predicate": {
+											"items": "minecraft:shears"
+										}
+									}
+								},
+								{
+									"condition": "minecraft:inverted",
+									"term": {
+										"condition": "minecraft:match_tool",
+										"predicate": {
+											"predicates": {
+												"minecraft:enchantments": [
+													{
+														"enchantments": "minecraft:silk_touch",
+														"levels": {
+															"min": 1
+														}
+													}
+												]
+											}
+										}
+									}
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/data/minecraft/loot_table/blocks/big_dripleaf_stem.json
+++ b/data/minecraft/loot_table/blocks/big_dripleaf_stem.json
@@ -1,0 +1,67 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "name": "minecraft:big_dripleaf"
+            },
+            {
+              "type": "minecraft:alternatives",
+              "children": [
+                {
+                  "type": "minecraft:item",
+                  "conditions": [
+                    {
+                      "chances": [
+                        0.1,
+                        0.14285715,
+                        0.25,
+                        1.0
+                      ],
+                      "condition": "minecraft:table_bonus",
+                      "enchantment": "minecraft:fortune"
+                    }
+                  ],
+                  "name": "minecraft:small_dripleaf"
+                },
+                {
+                  "type": "minecraft:item",
+                  "name": "minecraft:big_dripleaf"
+                }
+              ],
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "minecraft:blocks/big_dripleaf_stem"
+}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,7 @@
 {
 	"pack": {
-		"min_format": [101, 1],
-    "max_format": [101, 1],
+		"min_format": [107, 0],
+    "max_format": [107, 0],
 		"description": [
       {
         "text":"Grid",
@@ -12,7 +12,7 @@
         "color":"dark_gray"
       },
       {
-        "text":"ᴠ",
+        "text":"v",
         "color":"white"
       },
       {


### PR DESCRIPTION
Add numerous recipes (crafting, smelting, blasting, smoking, smithing, stonecutting) and new loot tables for big_dripleaf and its stem. Key changes:
- Add many new crafting recipes (clay_ball, cobweb, various copper_golem spawn eggs and waxed variants, snowball variants, sponge, string, invisible item frame, soul_campfire_from_campfire, etc.)
- Add smelting/smoking recipes (honey_block) and normalize leather-from-rotten-flesh recipes/experience
- Reorder/result fixes in existing blasting/smelting recipes (raw_*_block → *_block)
- Add smithing recipe for anvil and stonecutting for mangrove_roots
- Add lore/components to campfire/soul_campfire and fix unstable TNT lore formatting
- Add loot tables for big_dripleaf and big_dripleaf_stem
- Bump pack.mcmeta format and change version text; update GitHub publish workflow game-versions to 26.2 These changes expand content and correct recipe/metadata formatting.